### PR TITLE
Normalise the data loader to NFC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,19 +15,20 @@ written.
 
 ## [Unreleased] — targeting 0.2.0
 
-### Changed
-
-- `src/data_loader/data_loader.jl` is now Unicode NFC-normalised. It stored `ṗ` as a base letter
-  plus a combining mark, three times, inherited from macOS rather than chosen. Nothing about the
-  compiled code changes — Julia's parser normalises identifiers to NFC — but a `grep` pattern or an
-  editor search typed in NFC now matches, where before it silently matched nothing. The file is
-  byte-equal to the NFC normalisation of its predecessor; no string literal was affected, and no
-  changed line falls inside a doctest block.
-
 ### New Features
 
 ### Bug Fixes
 
 ### Breaking Changes
+
+### Changed
+
+- `src/data_loader/data_loader.jl` is now Unicode NFC-normalised. It stored `ṗ` as a base letter
+  plus a combining mark, three times, inherited from macOS rather than chosen; `q̇` has no
+  precomposed codepoint and is unchanged. Nothing about the compiled code changes — Julia's parser
+  normalises identifiers to NFC, and all three changed lines are `NamedTuple` type parameters in
+  function signatures — but a `grep` pattern or an editor search typed in NFC now matches, where
+  before it silently matched nothing. The file is byte-equal to the NFC normalisation of its
+  predecessor; no string literal was affected, and no changed line falls inside a doctest block.
 
 ## Open Issues

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ written.
 
 ## [Unreleased] — targeting 0.2.0
 
+### Changed
+
+- `src/data_loader/data_loader.jl` is now Unicode NFC-normalised. It stored `ṗ` as a base letter
+  plus a combining mark, three times, inherited from macOS rather than chosen. Nothing about the
+  compiled code changes — Julia's parser normalises identifiers to NFC — but a `grep` pattern or an
+  editor search typed in NFC now matches, where before it silently matched nothing. The file is
+  byte-equal to the NFC normalisation of its predecessor; no string literal was affected, and no
+  changed line falls inside a doctest block.
+
 ### New Features
 
 ### Bug Fixes

--- a/src/data_loader/data_loader.jl
+++ b/src/data_loader/data_loader.jl
@@ -291,7 +291,7 @@ function data_tensors_from_geometric_solution(solution::GeometricSolution{T,
         T2,
         TT,
         NT}) where {T <: Number, T2 <: Number, TT <: TimeSeries{T2},
-        TuT, NT <: NamedTuple{(:t, :q, :p, :q̇, :ṗ), TuT}}
+        TuT, NT <: NamedTuple{(:t, :q, :p, :q̇, :ṗ), TuT}}
     sys_dim, input_time_steps = length(solution.dataser.q[0]), length(solution.t)
     data = (q = zeros(T, sys_dim, input_time_steps, 1),
         p = zeros(T, sys_dim, input_time_steps, 1))
@@ -345,7 +345,7 @@ function DataLoader(solution::GeometricSolution{T, T2, TT, NT},
         TT <: TimeSeries{T2},
         TuT,
         NT <: Union{
-            NamedTuple{(:t, :q, :p, :q̇, :ṗ), TuT},
+            NamedTuple{(:t, :q, :p, :q̇, :ṗ), TuT},
             NamedTuple{(:t, :q, :v), TuT},
             NamedTuple{(:t, :q, :q̇), TuT}}}
     data = data_tensors_from_geometric_solution(solution)
@@ -404,7 +404,7 @@ function DataLoader(ensemble_solution::EnsembleSolution{T, T1, Vector{ST}};
         T1,
         TuT,
         TT <: TimeSeries{T1},
-        ST <: GeometricSolution{T, T1, TT, NamedTuple{(:t, :q, :p, :q̇, :ṗ), TuT}}
+        ST <: GeometricSolution{T, T1, TT, NamedTuple{(:t, :q, :p, :q̇, :ṗ), TuT}}
 }
     sys_dim = length(ensemble_solution.s[1].q[0])
     input_time_steps = length(ensemble_solution.t)


### PR DESCRIPTION
Converts `src/data_loader/data_loader.jl` from NFD to Unicode NFC. It stored `ṗ` as a base letter plus a combining mark, three times — an artefact of macOS, not a decision.

Part of a tree-wide conversion (`Tasks/Normalise the Julia sources to NFC.md`). This is the only affected file in the package.

## Why

Julia's parser normalises identifiers to NFC, so the compiled symbols were already precomposed and dispatch is untouched. The cost of NFD is entirely in tooling: **a pattern typed in NFC matches nothing at all in an NFD file, silently.**

`q̇` occurs six times and is unchanged — a dot above `q` has no precomposed codepoint. The invariant is `s == Unicode.normalize(s, :NFC)`, not the absence of combining marks.

## How to review

The file is byte-equal to the NFC normalisation of its predecessor, and `Meta.parseall` gives an **identical `Expr` tree** for base and head — which settles the string-literal question at the same time, since `Expr` equality recurses through strings.

All three changed lines are `NamedTuple` type parameters in function signatures (`:294`, `:348`, `:407`). The file's three `jldoctest` blocks are at lines 23–45, 79–94 and 98–111, so no changed line falls inside one — worth checking directly, because `Pkg.test()` does not run doctests and a green suite would have said nothing about them.

## Verification

| what | result |
|:--|:--|
| diff is exactly the NFC normalisation | 1/1 file |
| `Meta.parseall` tree, base vs head | identical |
| `Pkg.test()` | **3272 passed, 0 failed** |
| no changed line inside a `jldoctest` block | verified against fence ranges |
| `using ReducedComplexityModeling` | loads |

**Not applicable** rather than unmeasured: piracy, inference, allocations — identical parse tree, no literal altered.

## Pre-PR verification

One structural fix in a follow-up commit: `### Changed` is a fourth heading this seeded changelog does not carry, and it sat above the three that it does. Moved below them.

## Pre-existing, deliberately not addressed

`redundant-boolean` findings at `src/data_loader/data_loader.jl:277,479,481` (`autoencoder == true`), all in other functions seventeen or more lines from the nearest hunk.
